### PR TITLE
Add the use of 'unlink-early'

### DIFF
--- a/docker-ssh-auth-sock
+++ b/docker-ssh-auth-sock
@@ -45,5 +45,5 @@ while true; do
     COMMAND="mkdir -p /ssh-auth-sock-hack && mount -o bind /ssh-auth-sock-hack $(dirname $SSH_AUTH_SOCK) && rmdir $SSH_AUTH_SOCK"
     echo ctr -n services.linuxkit tasks exec --exec-id 'ssh-$(hostname)-$$' '$(ctr -n services.linuxkit tasks ls -q | grep docker)' sh -c \"$COMMAND\" > "$TTY_FILE" || true
     sleep 1.25
-    socat "EXEC:\"docker run -i --rm -v $(dirname $SSH_AUTH_SOCK):$(dirname $SSH_AUTH_SOCK) alpine/socat UNIX-LISTEN:$SSH_AUTH_SOCK,reuseaddr,fork,mode=0777 -\"" "EXEC:\"socat - UNIX:${SSH_AUTH_SOCK}\"" || true
+    socat "EXEC:\"docker run -i --rm -v $(dirname $SSH_AUTH_SOCK):$(dirname $SSH_AUTH_SOCK) alpine/socat UNIX-LISTEN:$SSH_AUTH_SOCK,reuseaddr,unlink-early,fork,mode=0777 -\"" "EXEC:\"socat - UNIX:${SSH_AUTH_SOCK}\"" || true
 done


### PR DESCRIPTION
My first attempt to use this in a Mac "brew service" seemed to be
working, but then it stopped, and I started seeing this error:

2020/02/20 22:15:50 socat[1] E "/private/tmp/com.apple.launchd.ECGuESY9e2/Listeners" exists

Research led me to:

https://manpages.debian.org/testing/socat/socat.1.en.html

  UNIX-LISTEN:<filename>

  Listens on <filename> using a UNIX domain stream socket and accepts a
  connection. If <filename> exists and is not a socket, this is an error.
  If <filename> exists and is a UNIX domain socket, binding to the address
  fails (use option unlink-early!). Note that opening this address usually
  blocks until a client connects. Beginning with socat version 1.4.3, the
  file system entry is removed when this address is closed (but see option
  unlink-close) (example

Adding 'unlink-early' seems to have fixed it.